### PR TITLE
Removed reference to deleted OwnerModule and removed attributes

### DIFF
--- a/ScrubBot/Modules/AdminModule.cs
+++ b/ScrubBot/Modules/AdminModule.cs
@@ -7,11 +7,10 @@ using ScrubBot.Domain;
 using ScrubBot.Extensions;
 
 using System.Threading.Tasks;
-using ScrubBot.Attributes;
 
 namespace ScrubBot.Modules
 {
-    [RequireRoleOrOwner(GuildPermission.Administrator, Group = nameof(AdminModule)), RequireOwner(Group = nameof(AdminModule))]
+    [RequireUserPermission(GuildPermission.Administrator, Group = nameof(AdminModule)), RequireOwner(Group = nameof(AdminModule))]
     public class AdminModule : Module
     {
         public AdminModule(Tools tools) : base(tools) {}

--- a/ScrubBot/Modules/SettingsModule.cs
+++ b/ScrubBot/Modules/SettingsModule.cs
@@ -40,8 +40,6 @@ namespace ScrubBot.Modules
             {
                 if (command.Name == "Help") continue;
 
-                if (command.Module.Name == typeof(OwnerModule).Name) continue;
-
                 string embedFieldText = command.Summary;
 
                 if (command.Parameters.Count > 0)


### PR DESCRIPTION
Modify:
- Removed reference to OwnerModule in SettingsModule's help command
- Removed usage of removed RequireRoleOrOwner atribute